### PR TITLE
Cmake hx711.c file include added

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 # List any additional sources here
-target_sources(${CMAKE_PROJECT_NAME} PUBLIC application.c)
+target_sources(${CMAKE_PROJECT_NAME} PUBLIC application.c hx711.c)
 
 # If you added some folder with header files you need to list them here
 target_include_directories(


### PR DESCRIPTION
Hello,

I added a file hx711.c to the src/CMakeLists.txt file. In this file you have to list all of the *.c files that should be compiled with the project.

I hope this solves the issues.

Jakub Smejkal

Firmware Developer

HARDWARIO a.s.